### PR TITLE
add: nodemcu esp8266 definitions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -38,3 +38,7 @@
 [submodule "addons/lpeg/module"]
 	path = addons/lpeg/module
 	url = https://github.com/LuaCATS/lpeg.git
+[submodule "addons/nodemcu-esp8266/module"]
+	path = addons/nodemcu-esp8266/module
+	url = https://github.com/serg3295/nodeMCU-emmylua.git
+	branch = nodemcu-esp8266

--- a/addons/nodemcu-esp8266/info.json
+++ b/addons/nodemcu-esp8266/info.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
+  "name": "NodeMCU ESP8266",
+  "description": "Definitions for NodeMCU, Lua based firmware for the ESP8266 WiFi SoC from Espressif"
+}


### PR DESCRIPTION
Definition files for [NodeMCU](https://nodemcu.readthedocs.io/en/dev/), a Lua based firmware for the ESP8266 WiFi SoC from Espressif, to use with [Lua Language Server](https://github.com/LuaLS/lua-language-server).
