### PR TITLE
Add Penlight addon

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -64,3 +64,7 @@
 [submodule "addons/slnunicode/module"]
 	path = addons/slnunicode/module
 	url = https://github.com/LuaCATS/slnunicode.git
+[submodule "addons/penlight/module"]
+	path = addons/penlight/module
+	url = https://github.com/goldenstein64/pl-definitions
+	branch = publish

--- a/addons/penlight/info.json
+++ b/addons/penlight/info.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+	"name": "Penlight",
+	"description": "Definitions for the Penlight 1.13.1 library."
+}


### PR DESCRIPTION
Closes #8.

This includes all definitions from [goldenstein64/pl-definitions/publish](https://github.com/goldenstein64/pl-definitions/tree/publish). See the README on the [main branch](https://github.com/goldenstein64/pl-definitions) for info on exactly what was added. 

This has a plugin that detects `require("pl")`, `require("pl.compat")`, and comment counterparts for injecting Penlight modules into the global namespace. If a plugin is too much, I can instead publish two separate addons, one with global injections and another without.