### PR TITLE
Add argparse addon

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -71,3 +71,7 @@
 	path = addons/xmake/module
 	url = https://github.com/LelouchHe/xmake-luals-addon.git
 	branch = publish
+[submodule "addons/argparse/module"]
+	path = addons/argparse/module
+	url = https://github.com/goldenstein64/argparse-definitions.git
+	branch = publish

--- a/addons/argparse/info.json
+++ b/addons/argparse/info.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+	"name": "argparse",
+	"description": "Definitions for the argparse 0.7.1 library."
+}


### PR DESCRIPTION
Closes #9.

This includes all definitions from [goldenstein64/argparse-definitions/publish](https://github.com/goldenstein64/argparse-definitions/tree/publish). See the README on the [main branch](https://github.com/goldenstein64/argparse-definitions) for info on exactly what was added.