### PR TITLE
Add LÖVE Nuklear addon

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -71,3 +71,7 @@
 	path = addons/xmake/module
 	url = https://github.com/LelouchHe/xmake-luals-addon.git
 	branch = publish
+[submodule "addons/love-nuklear/module"]
+	path = addons/love-nuklear/module
+	url = https://github.com/goldenstein64/love-nuklear-definitions.git
+	branch = publish

--- a/addons/love-nuklear/info.json
+++ b/addons/love-nuklear/info.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+	"name": "LÖVE Nuklear",
+	"description": "Definitions for the LÖVE Nuklear 2.6.1 library."
+}


### PR DESCRIPTION
Closes #10.

This includes definitions from [goldenstein64/love-nuklear-definitions/publish](https://github.com/goldenstein64/love-nuklear-definitions/tree/publish). See the README on the [main branch](https://github.com/goldenstein64/love-nuklear-definitions) for info on exactly what was added.