### PR TITLE
Update all URLs to the schema file “addon_info.schema.json”

### DIFF
--- a/addons/argparse/info.json
+++ b/addons/argparse/info.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "argparse",
   "description": "Definitions for the argparse 0.7.1 library.",
   "size": 42443,

--- a/addons/bee/info.json
+++ b/addons/bee/info.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "description": "Definitions for the bee.lua library",
   "size": 8674,
   "hasPlugin": false

--- a/addons/busted/info.json
+++ b/addons/busted/info.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "description": "Definitions for the busted testing suite",
   "size": 6808,
   "hasPlugin": false

--- a/addons/cc-tweaked/info.json
+++ b/addons/cc-tweaked/info.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "CC: Tweaked",
   "description": "Definitions for the CC: Tweaked Lua API",
   "size": 245159,

--- a/addons/cocos4.0/info.json
+++ b/addons/cocos4.0/info.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "Cocos",
   "description": "Definitions for the Cocos game engine",
   "size": 930266,

--- a/addons/love-nuklear/info.json
+++ b/addons/love-nuklear/info.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "LÖVE Nuklear",
   "description": "Definitions for the LÖVE Nuklear 2.6.1 library.",
   "size": 61395,

--- a/addons/love2d/info.json
+++ b/addons/love2d/info.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "LÖVE",
   "description": "Definitions for the LÖVE 2D game framework",
   "size": 506301,

--- a/addons/lovr/info.json
+++ b/addons/lovr/info.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "LÖVR",
   "description": "Definitions for the LÖVR 3D framework",
   "size": 384055,

--- a/addons/lpeg/info.json
+++ b/addons/lpeg/info.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "LPeg",
   "description": "Definitions for the LPeg library",
   "size": 14430,

--- a/addons/luaecs/info.json
+++ b/addons/luaecs/info.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "ECS Lua",
   "description": "Definitions for ECS Lua, a simple Entity-Component library",
   "size": 11375,

--- a/addons/luafilesystem/info.json
+++ b/addons/luafilesystem/info.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "LuaFileSystem",
   "description": "Definitions for the LuaFileSystem library",
   "size": 7806,

--- a/addons/luaharfbuzz/info.json
+++ b/addons/luaharfbuzz/info.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "luaharfbuzz",
   "description": "Definitions for the luaharfbuzz library",
   "size": 26421,

--- a/addons/luasocket/info.json
+++ b/addons/luasocket/info.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "LuaSocket",
   "description": "Definitions for the LuaSocket library",
   "size": 23063,

--- a/addons/luassert/info.json
+++ b/addons/luassert/info.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "description": "Definitions for the luassert assertion library",
   "size": 36858,
   "hasPlugin": false

--- a/addons/luazip/info.json
+++ b/addons/luazip/info.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "LuaZip",
   "description": "Definitions for the LuaZip library",
   "size": 6242,

--- a/addons/luvit/info.json
+++ b/addons/luvit/info.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "Luvit",
   "description": "Definitions for the Luvit framework",
   "size": 309868,

--- a/addons/lzlib/info.json
+++ b/addons/lzlib/info.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "lzlib",
   "description": "Definitions for the lzlib library",
   "size": 4598,

--- a/addons/md5/info.json
+++ b/addons/md5/info.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "md5",
   "description": "Definitions for the md5 library",
   "size": 5163,

--- a/addons/moonloader/info.json
+++ b/addons/moonloader/info.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "MoonLoader",
   "description": "Definitions for MoonLoader, a modding interface for GTA: SA",
   "size": 239091,

--- a/addons/openresty/info.json
+++ b/addons/openresty/info.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "OpenResty",
   "description": "Definitions for the OpenResty scriptable web platform",
   "size": 323438,

--- a/addons/penlight/info.json
+++ b/addons/penlight/info.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "Penlight",
   "description": "Definitions for the Penlight 1.13.1 library.",
   "size": 244203,

--- a/addons/skynet/info.json
+++ b/addons/skynet/info.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "description": "Definitions for skynet, a framework for online game servers",
   "size": 60543,
   "hasPlugin": false

--- a/addons/slnunicode/info.json
+++ b/addons/slnunicode/info.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "slnunicode",
   "description": "Definitions for the slnunicode library",
   "size": 14387,

--- a/addons/tex-lualatex/info.json
+++ b/addons/tex-lualatex/info.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "LuaLaTeX",
   "description": "Definitions for the TeX macro system LuaLaTeX",
   "size": 8898,

--- a/addons/tex-luatex/info.json
+++ b/addons/tex-luatex/info.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "LuaTeX",
   "description": "Definitions for the TeX engine LuaTeX",
   "size": 992084,

--- a/addons/xmake/info.json
+++ b/addons/xmake/info.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "Xmake",
   "description": "Definitions for Xmake, a cross-platform build utility based on Lua",
   "size": 96832,


### PR DESCRIPTION
Instead of the URL to the old location

	https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json

use the URL to the new location of the LLS-Addons repository.

	https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json

Add additionally the missing $schema field to the info.json of the moonloader addon.