### PR TITLE
Add garrysmod addon

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -98,3 +98,7 @@
 [submodule "addons/tex-luametatex/module"]
 	path = addons/tex-luametatex/module
 	url = https://github.com/LuaCATS/tex-luametatex.git
+[submodule "addons/garrysmod/module"]
+	path = addons/garrysmod/module
+	url = https://github.com/luttje/glua-api-snippets.git
+	branch = lua-language-server-addon

--- a/addons/garrysmod/info.json
+++ b/addons/garrysmod/info.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
+  "name": "Garry's Mod",
+  "description": "Definitions for the game Garry's Mod"
+}


### PR DESCRIPTION
Closes #48

Adds addon with definitions for the game [Garry's Mod](https://gmod.facepunch.com/). The definitions are automatically generated and based on [the official wiki](https://wiki.facepunch.com/gmod)

The submodule points to the `lua-language-server-addon` branch in [this repo](https://github.com/luttje/glua-api-snippets/tree/lua-language-server-addon)