### PR TITLE
Addon for Transformice's Module API

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -105,3 +105,7 @@
 [submodule "addons/yue/module"]
 	path = addons/yue/module
 	url = https://github.com/Frityet/luayue-definitions.git
+[submodule "addons/transformice/module"]
+	path = addons/transformice/module
+	url = https://github.com/MouseTool/tfm-types.git
+	branch = luals-addon

--- a/addons/transformice/info.json
+++ b/addons/transformice/info.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
+  "name": "Transformice",
+  "description": "Definitions for the Transformice game's Module API"
+}


### PR DESCRIPTION
adds support for transformice's [module api](https://transformice.fandom.com/wiki/Lua). the API runs with LuaJ 3.0 and not standard LuaC nor LuaJIT — it is basically an interpreter written against half-baked Lua 5.2 spec

the addon is suggested when `tfm.*` is typed.