### PR TITLE
Add LuaLogging addon

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -89,3 +89,7 @@
 [submodule "addons/bee/module"]
 	path = addons/bee/module
 	url = https://github.com/LuaCATS/bee.git
+[submodule "addons/lualogging/module"]
+	path = addons/lualogging/module
+	url = https://github.com/goldenstein64/lualogging-definitions.git
+	branch = publish

--- a/addons/lualogging/info.json
+++ b/addons/lualogging/info.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+	"name": "LuaLogging",
+	"description": "Definitions for LuaLogging 1.8.2"
+}


### PR DESCRIPTION
Closes #67.

This adds definitions for [lunarmodules/lualogging](https://github.com/lunarmodules/lualogging) from [goldenstein64/lualogging-definitions/publish](https://github.com/goldenstein64/lualogging-definitions/tree/publish). See the README on the [main branch](https://github.com/goldenstein64/lualogging-definitions) to see what was added.

This has a plugin that detects `require` calls to this library's appenders and injects them into fields on the `logging` table.