### PR TITLE
Add dkjson addon

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -142,3 +142,7 @@
 [submodule "addons/lldebugger/module"]
 	path = addons/lldebugger/module
 	url = https://github.com/b0mbie/local-lua-debugger-api.git
+[submodule "addons/dkjson/module"]
+	path = addons/dkjson/module
+	url = https://github.com/goldenstein64/dkjson-definitions
+	branch = publish

--- a/addons/dkjson/info.json
+++ b/addons/dkjson/info.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
+	"name": "dkjson",
+	"description": "library definitions for dkjson 2.6"
+}


### PR DESCRIPTION
This adds definitions for the [dkjson](http://dkolf.de/src/dkjson-lua.fsl) module from [goldenstein64/dkjson-definitions/publish](https://github.com/goldenstein64/dkjson-definitions/tree/publish). A README can be found on the [main branch](https://github.com/goldenstein64/dkjson-definitions/tree/main).