### PR TITLE
Add Lua CJSON addon

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -149,3 +149,7 @@
 [submodule "addons/lapis/module"]
 	path = addons/lapis/module
 	url = https://github.com/Sylviettee/lapis-annotations.git
+[submodule "addons/lua-cjson/module"]
+	path = addons/lua-cjson/module
+	url = https://github.com/goldenstein64/lua-cjson-definitions
+	branch = publish

--- a/addons/lua-cjson/info.json
+++ b/addons/lua-cjson/info.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
+	"name": "Lua CJSON",
+	"description": "Definitions for the Lua CJSON module"
+}

--- a/addons/lua-cjson/info.json
+++ b/addons/lua-cjson/info.json
@@ -1,5 +1,5 @@
 {
 	"$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
-	"name": "Lua CJSON",
+	"name": "CJSON",
 	"description": "Definitions for the Lua CJSON module"
 }


### PR DESCRIPTION
This adds definitions for the [Lua CJSON](https://kyne.com.au/~mark/software/lua-cjson.php) module from [goldenstein64/lua-cjson-definitions/publish](https://github.com/goldenstein64/lua-cjson-definitions/tree/publish). A README can be found on the [main branch](https://github.com/goldenstein64/lua-cjson-definitions/tree/main).