### PR TITLE
Update Lua CJSON to use OpenResty's fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -149,3 +149,7 @@
 [submodule "addons/lapis/module"]
 	path = addons/lapis/module
 	url = https://github.com/Sylviettee/lapis-annotations.git
+[submodule "addons/lua-cjson/module"]
+	path = addons/lua-cjson/module
+	url = https://github.com/goldenstein64/lua-cjson-definitions
+	branch = publish

--- a/.gitmodules
+++ b/.gitmodules
@@ -146,3 +146,6 @@
 	path = addons/dkjson/module
 	url = https://github.com/goldenstein64/dkjson-definitions
 	branch = publish
+[submodule "addons/lapis/module"]
+	path = addons/lapis/module
+	url = https://github.com/Sylviettee/lapis-annotations.git

--- a/addons/lapis/info.json
+++ b/addons/lapis/info.json
@@ -1,0 +1,5 @@
+{
+   "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
+   "name": "Lapis",
+   "description": "Definitions for the Lapis web framework."
+}

--- a/addons/lapis/info.json
+++ b/addons/lapis/info.json
@@ -1,5 +1,7 @@
 {
-   "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
-   "name": "Lapis",
-   "description": "Definitions for the Lapis web framework."
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
+  "name": "Lapis",
+  "description": "Definitions for the Lapis web framework.",
+  "size": 143642,
+  "hasPlugin": false
 }

--- a/addons/lua-cjson/info.json
+++ b/addons/lua-cjson/info.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
+	"name": "Lua CJSON",
+	"description": "Definitions for the Lua CJSON module"
+}

--- a/addons/lua-cjson/info.json
+++ b/addons/lua-cjson/info.json
@@ -1,5 +1,5 @@
 {
 	"$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
-	"name": "Lua CJSON",
+	"name": "CJSON",
 	"description": "Definitions for the Lua CJSON module"
 }


### PR DESCRIPTION
The most widely used version of CJSON (to my knowledge) is OpenResty's fork of the module, found at [LuaRocks](https://luarocks.org/modules/openresty/lua-cjson) and at [openresty/lua-cjson](https://github.com/openresty/lua-cjson). My definitions only accounted for the original module, found [here](https://kyne.com.au/~mark/software/lua-cjson.php). This PR updates the CJSON definitions to reflect OpenResty's fork.