### PR TITLE
Add stormworks addon lua

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -153,3 +153,6 @@
 	path = addons/lua-cjson/module
 	url = https://github.com/goldenstein64/lua-cjson-definitions
 	branch = publish
+[submodule "addons/StormworksAddonLua/module"]
+	path = addons/StormworksAddonLua/module
+	url = https://github.com/Ierdna100/StormworksAddonLua

--- a/addons/StormworksAddonLua/info.json
+++ b/addons/StormworksAddonLua/info.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
+    "name": "Stormworks Addon Lua",
+    "description": "Definitions for Stormworks Addon built-in code. Does not support any microcontroller related definitions."
+}


### PR DESCRIPTION
Added support for Stormworks addon Lua. Contains definition for the server class, custom math class and others. Currently lacking server callbacks due to LuaLS not supporting them.

Related issue: #105 