### PR TITLE
fixed config.json on RSIDEA

### DIFF
--- a/addons/RavenscriptIDEA/info.json
+++ b/addons/RavenscriptIDEA/info.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://github.com/LuaLS/LLS-Addons/blob/main/schemas/addon_info.schema.json",
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "Ravenscript IDEA",
   "description": "The NEXT snippet addons for ravenscript coding.",
   "size": 268031,


### PR DESCRIPTION
fixed config.json on RSIDEA
OMG the config.json shouldn't have comments
when i tried to enable RSIDEA,the Addons maneger gave me a error. after i deleted config.json's comments,it works!
so i start a pr again, sorry