### PR TITLE
Add relative import addon.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -169,3 +169,6 @@
 [submodule "addons/umbrella/module"]
 	path = addons/umbrella/module
 	url = https://github.com/demiurgeQuantified/UmbrellaAddon.git
+[submodule "addons/luals-relative-imports/module"]
+	path = addons/luals-relative-imports/module
+	url = https://github.com/qeffects/luals-relative-require.git

--- a/addons/luals-relative-imports/info.json
+++ b/addons/luals-relative-imports/info.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/carsakiller/LLS-Addons/main/schemas/addon_info.schema.json",
+  "name": "LuaLS Relative Imports",
+  "description": "A plugin to enable annotations for LuaImport",
+  "size": 48004,
+  "hasPlugin": true
+}


### PR DESCRIPTION
What this fixes: Relative requires in lua suffer from losing all emmylua/autogenerated annotations because Lua Language server can't follow through dynamic paths. Example:

```lua
local path = (...):gsub(".file", "")
local anotherFile = require(path..".anotherFile")
```

This allows for your library to work independent of what the external file system looks like, for example your library could be copy pasted in /libraries/* /libs/* /whatever/* and you could import adjacent files regardless.
But, anotherFile is now a completely unknown variable and you have to manually annotate it.

This together with https://github.com/Keyslam/LuaImport adds an import("./anotherFile") function that preserves type information from the required file.