### PR TITLE
Add Starfall Ex addon

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -180,3 +180,6 @@
 [submodule "addons/fenster/module"]
 	path = addons/fenster/module
 	url = https://github.com/jonasgeiler/lua-fenster-type-definitions.git
+[submodule "addons/starfallex/module"]
+	path = addons/starfallex/module
+	url = https://github.com/Periapsises/Starfall-LLS

--- a/addons/starfallex/info.json
+++ b/addons/starfallex/info.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
+  "name": "Starfall Ex",
+  "description": "Definitions for the Starfall Ex addon from Garry's Mod."
+}
+  


### PR DESCRIPTION
Adds the [Starfall-LLS](https://github.com/Periapsises/Starfall-LLS) addon, providing support for the [StarfallEx](https://github.com/thegrb93/StarfallEx) API within Lua LS.

Resolves #150