### PR TITLE
Add smbx2-lunalua addon

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -183,3 +183,7 @@
 [submodule "addons/starfallex/module"]
 	path = addons/starfallex/module
 	url = https://github.com/Periapsises/Starfall-LLS
+[submodule "addons/smbx2-lunalua/module"]
+	path = addons/smbx2-lunalua/module
+	url = https://github.com/Wild-W/smbx2-lunalua-luacats
+	branch = publish

--- a/addons/smbx2-lunalua/info.json
+++ b/addons/smbx2-lunalua/info.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
+    "name": "SMBX2 LunaLua",
+    "description": "Definitions for LunaLua + SMBX2 APIs"
+}


### PR DESCRIPTION
Add definitions for [LunaLua](https://github.com/WohlSoft/LunaLua) (a fork of LuaJIT made for SMBX) and [SMBX2](https://codehaus.wohlsoft.ru) APIs.

Definitions are *accurate* but they are not *comprehensive* (it's probably around 80% or more complete, excluding modules). Updates are planned and hopefully some contributors from the smbx2 community will help finish this in the future.