### PR TITLE
Add the nCine addon

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -202,3 +202,7 @@
 [submodule "addons/scribunto/module"]
 	path = addons/scribunto/module
 	url = https://github.com/Dianliang233/scribunto-addon
+[submodule "addons/ncine/module"]
+	path = addons/ncine/module
+	url = https://github.com/nCine/nCine-LuaCATS.git
+	branch = addon

--- a/addons/ncine/info.json
+++ b/addons/ncine/info.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
+  "name": "nCine",
+  "description": "Definitions for the nCine, a cross-platform 2D game framework with an emphasis on performance"
+}


### PR DESCRIPTION
I would like to contribute the CATS definitions for the [nCine](https://ncine.github.io/), an open source cross-platform 2D game framework that can be used with both C++ and Lua.

The work took 2-3 weeks of my spare time and gave me the opportunity to review both the C++ Doxygen documentation and the Lua API itself. I would be really glad and proud if it gets accepted as an official addon for the Lua Language Server. 😊

Please don't hesitate to provide feedback and let me know if there is anything that should be changed. 🙏🏻 
GitHub Issue: #191.