### PR TITLE
Update the nCine addons submodule

### DIFF
--- a/addons/ncine/info.json
+++ b/addons/ncine/info.json
@@ -2,6 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "nCine",
   "description": "Definitions for the nCine, a cross-platform 2D game framework with an emphasis on performance",
-  "size": 182474,
+  "size": 182472,
   "hasPlugin": false
 }


### PR DESCRIPTION
I have updated the nCine submodule commit to point to the latest one where I have removed the trailing commas from `config.json` and `.luarc.json`.

Update: I have rebased this branch on top of the latest C.I. fixes (2).