### PR TITLE
Umbrella (Unstable) addon

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -206,3 +206,6 @@
 	path = addons/ncine/module
 	url = https://github.com/nCine/nCine-LuaCATS
 	branch = addon
+[submodule "addons/umbrella-unstable/module"]
+	path = addons/umbrella-unstable/module
+	url = https://github.com/demiurgeQuantified/UmbrellaAddon-Unstable

--- a/addons/umbrella-unstable/info.json
+++ b/addons/umbrella-unstable/info.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
+  "name": "Umbrella (Unstable)",
+  "description": "Definitions for the Unstable version of Project Zomboid's API",
+  "size": 4842236,
+  "hasPlugin": false
+}

--- a/addons/umbrella-unstable/info.json
+++ b/addons/umbrella-unstable/info.json
@@ -2,6 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "Umbrella (Unstable)",
   "description": "Definitions for the Unstable version of Project Zomboid's API",
-  "size": 4842236,
+  "size": 7396714,
   "hasPlugin": false
 }


### PR DESCRIPTION
Adds the Umbrella (Unstable) addon, which is type definitions for the Unstable (public beta) version of Project Zomboid's API. The justification for having two versions of the same addon is because these Unstable periods often last a long time (the previous one was two years) and each have significant playerbases and modding interest.