### PR TITLE
Update HLA-VScript module

### DIFF
--- a/addons/HLA-VScript/info.json
+++ b/addons/HLA-VScript/info.json
@@ -1,6 +1,6 @@
 {
   "name": "Half Life Alyx VScript API",
   "description": "Definitions for the Half Life Alyx Lua API.",
-  "size": 217875,
+  "size": 217788,
   "hasPlugin": false
 }


### PR DESCRIPTION
Fixes a syntax error causing the addon to fail enabling.

Comments present in the [example config.json on the wiki](https://luals.github.io/wiki/addons/#configjson) cause a syntax error when trying to enable the addon from the manager. I have removed all comments and it seems to enable correctly now.

The exact log was:

```
[2025-01-23 17:52:28] |  VERBOSE  |       Command      | Executing "enable" ({"command":"enable","data":{"name":"HLA-VScript"}})
[2025-01-23 17:52:29] |   DEBUG   |        Addon       | Initialized submodule
[2025-01-23 17:52:29] |   DEBUG   |        Addon       | Submodule up to date
[2025-01-23 17:52:29] |   ERROR   |        Addon       | Failed to read config.json file for HLA-VScript (SyntaxError: Expected property name or '}' in JSON at position 7 (line 2 column 5))
[2025-01-23 17:52:29] |   ERROR   |    Enable Addon    | Failed to enable HLA-VScript!
[2025-01-23 17:52:29] |   ERROR   |    Enable Addon    | SyntaxError: Expected property name or '}' in JSON at position 7 (line 2 column 5)
[2025-01-23 17:52:30] |  VERBOSE  |       Command      | Executing "openLog" ({"command":"openLog"})
```