### PR TITLE
Use lovr-docs for lovr definitions;

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,7 +21,7 @@
 	url = https://github.com/LuaCATS/luaecs.git
 [submodule "addons/lovr/module"]
 	path = addons/lovr/module
-	url = https://github.com/LuaCATS/lovr.git
+	url = https://github.com/bjornbytes/lovr-docs
 [submodule "addons/luafilesystem/module"]
 	path = addons/luafilesystem/module
 	url = https://github.com/LuaCATS/luafilesystem.git

--- a/addons/lovr/info.json
+++ b/addons/lovr/info.json
@@ -2,6 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "LÖVR",
   "description": "Definitions for the LÖVR 3D framework",
-  "size": 384055,
+  "size": 897379,
   "hasPlugin": false
 }


### PR DESCRIPTION
Hello!  The lovr definitions are very old and it isn't clear how to update them.  I added a LuaCATS generator to lovr's main documentation repo and set up a GH actions script to keep them in sync with the docs and publish them on a [`cats`](https://github.com/bjornbytes/lovr-docs/tree/cats) branch.

Could we change the lovr addon here to point at these new up to date definition files?  I can open a PR here to bump the submodule whenever LÖVR does a new release, and people that want up-to-date definitions can always grab fresh ones from lovr-docs.