### PR TITLE
Update smbx2-lunalua module to smbxb5p3 apis

### DIFF
--- a/addons/smbx2-lunalua/info.json
+++ b/addons/smbx2-lunalua/info.json
@@ -2,6 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "SMBX2 LunaLua",
   "description": "Definitions for LunaLua + SMBX2 APIs",
-  "size": 653532,
+  "size": 676933,
   "hasPlugin": true
 }


### PR DESCRIPTION
This update:
* Adds support for API changes from the new SMBX2 release Beta 5 Patch 3
* Removes known incorrect deprecation warnings (triggerEvent())
* Adds several missing LunaLua classes
* Generally improves annotations for many of the existing classes
* Renames some classes to better reflect their name as defined by LunaLua patches