### PR TITLE
xmake addon repo directory changed

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,7 +73,7 @@
 	branch = publish
 [submodule "addons/xmake/module"]
 	path = addons/xmake/module
-	url = https://github.com/LelouchHe/xmake-luals-addon.git
+	url = https://github.com/xmake-io/xmake-luals-addon.git
 	branch = publish
 [submodule "addons/luaharfbuzz/module"]
 	path = addons/luaharfbuzz/module


### PR DESCRIPTION
xmake lsp addon repo hasn't been updated for 2 years, so a new repo under xmake-io has been created.

https://github.com/xmake-io/xmake-luals-addon