### PR TITLE
Update ftl-hyperspace

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -234,3 +234,4 @@
 [submodule "addons/ftl-hyperspace/module"]
 	path = addons/ftl-hyperspace/module
 	url = https://github.com/ranhai613/ftl-hs-lua-lls-addon.git
+	branch = publish

--- a/addons/ftl-hyperspace/info.json
+++ b/addons/ftl-hyperspace/info.json
@@ -2,6 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "FTL: Hyperspace",
   "description": "Definitions for FTL: Hyperspace lua api.",
-  "size": 349235,
+  "size": 344897,
   "hasPlugin": false
 }


### PR DESCRIPTION
Update for Hyperspace version 1.19.1.
In advance, thanks who will take care of this pr.

One question:
During update, I switched the target branch from `main` to `publish` for submodule. Should I add `branch = publish` to https://github.com/LuaLS/LLS-Addons/blob/main/.gitmodules ?