### PR TITLE
Fixed definitions for darkrp module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -241,3 +241,6 @@
 [submodule "addons/LuaPlayerYT/module"]
 	path = addons/LuaPlayerYT/module
 	url = https://github.com/antim0118/lpyt-lls-addon
+[submodule "addons/darkrp/module"]
+	path = addons/darkrp/module
+	url = https://github.com/EmekC/darkrp-luals.git

--- a/addons/darkrp/info.json
+++ b/addons/darkrp/info.json
@@ -1,4 +1,6 @@
+{
   "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "DarkRP",
   "description": "DarRP Definitions for Garry's Mod",
 }
+

--- a/addons/darkrp/info.json
+++ b/addons/darkrp/info.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "DarkRP",
-  "description": "DarRP Definitions for Garry's Mod"
+  "description": "DarRP Definitions for Garry's Mod",
+  "size": 69318,
+  "hasPlugin": false
 }
-

--- a/addons/darkrp/info.json
+++ b/addons/darkrp/info.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "DarkRP",
-  "description": "DarRP Definitions for Garry's Mod",
+  "description": "DarRP Definitions for Garry's Mod"
 }
 

--- a/addons/darkrp/info.json
+++ b/addons/darkrp/info.json
@@ -2,6 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "DarkRP",
   "description": "DarRP Definitions for Garry's Mod",
-  "size": 69173,
+  "size": 100965,
   "hasPlugin": false
 }

--- a/addons/darkrp/info.json
+++ b/addons/darkrp/info.json
@@ -1,0 +1,4 @@
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
+  "name": "DarkRP",
+  "description": "DarRP Definitions for Garry's Mod",
+}

--- a/addons/tex-luatex/info.json
+++ b/addons/tex-luatex/info.json
@@ -2,6 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "LuaTeX",
   "description": "Definitions for the TeX engine LuaTeX",
-  "size": 1204142,
+  "size": 1228564,
   "hasPlugin": false
 }


### PR DESCRIPTION
in one of my last commits the definitions were changed to the starfall library and are incorrect, i've fixed the definitions and wiki references.

