### PR TITLE
Celeste - Bosses Helper: Lua Addon

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -248,3 +248,6 @@
 	path = addons/darkrp/module
 	url = https://github.com/EmekC/darkrp-luals.git
   
+[submodule "addons/celeste-bosses-helper/module"]
+	path = addons/celeste-bosses-helper/module
+	url = https://github.com/TheDavSmasher/bosses-helper-addon

--- a/addons/celeste-bosses-helper/info.json
+++ b/addons/celeste-bosses-helper/info.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
+  "name": "Celeste - Dav's Bosses Helper: Lua Addon",
+  "description": "Definitions for the Bosses Helper Celeste mod Lua development API. All types are namespaced for their C# equivalent and values that are given as globals are defined."
+}


### PR DESCRIPTION
This addon creates definition files which provide the API necessary for other developers to utilize the mod's Lua API locally with type hints and autocomplete, providing a smoother development process for the pretty complex process required to fully develop a Boss with the Helper.

While this can be maintained by myself, I find the fact that the LLS provides these plugins the opportunity to show other people this system to help with their development through my tool.