### PR TITLE
feat: add hyprlua — LuaCATS annotations for Hyprland 0.55+

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -278,3 +278,6 @@
 	path = addons/ethos/module
 	url = https://github.com/flyingeek/ethos-lua-definitions.git
 	branch = luals-addon
+[submodule "addons/hyprlua/module"]
+	path = addons/hyprlua/module
+	url = https://github.com/qompassai/hyprlua

--- a/addons/hyprlua/info.json
+++ b/addons/hyprlua/info.json
@@ -2,6 +2,4 @@
   "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "hyprlua",
   "description": "LuaCATS type annotations and lua_ls addon for Hyprland 0.55+. Goal is to provide autocomplete, hover docs, and type-checking for the full hl.* global API.",
-  "size": 249975,
-  "hasPlugin": true
 }

--- a/addons/hyprlua/info.json
+++ b/addons/hyprlua/info.json
@@ -2,6 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "hyprlua",
   "description": "LuaCATS type annotations and lua_ls addon for Hyprland 0.55+. Goal is to provide autocomplete, hover docs, and type-checking for the full hl.* global API.",
-  "size": 0,
+  "size": 249975,
   "hasPlugin": true
 }

--- a/addons/hyprlua/info.json
+++ b/addons/hyprlua/info.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
+  "name": "hyprlua",
+  "description": "LuaCATS type annotations and lua_ls addon for Hyprland 0.55+. Goal is to provide autocomplete, hover docs, and type-checking for the full hl.* global API.",
+  "size": 0,
+  "hasPlugin": true
+}


### PR DESCRIPTION

Adds lua_ls addon providing full EmmyLua/LuaCATS type annotations for
the Hyprland >= 0.55 Lua config API. Covers the `hl.*` global,
dispatchers (`hl.dsp.*`), layout API, events, and typed config
keys.

Available on LuaRocks: https://luarocks.org/modules/phaedrusflow/hyprlua