### PR TITLE
feat(addons): 添加lua-bint子模块

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -278,3 +278,6 @@
 	path = addons/ethos/module
 	url = https://github.com/flyingeek/ethos-lua-definitions.git
 	branch = luals-addon
+[submodule "addons/lua-bint/module"]
+	path = addons/lua-bint/module
+	url = https://github.com/Yue-bin/lua-bint-type.git


### PR DESCRIPTION
新增lua-bint类型定义子模块，用于支持大整数运算的类型检查

see #333 