### PR TITLE
Update ethos addon to 26.1.0-RC5

### DIFF
--- a/addons/ethos/info.json
+++ b/addons/ethos/info.json
@@ -2,6 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "Ethos Lua (FrSky)",
   "description": "Definitions for the Ethos Lua API, used in FrSky transmitters.",
-  "size": 76776,
+  "size": 93484,
   "hasPlugin": false
 }


### PR DESCRIPTION
Automated update of ETHOS Lua definitions to version 26.1.0-RC5.