### PR TITLE
feat (forts): add forts plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -281,3 +281,7 @@
 [submodule "addons/lua-bint/module"]
 	path = addons/lua-bint/module
 	url = https://github.com/Yue-bin/lua-bint-type.git
+[submodule "addons/forts/module"]
+	path = addons/forts/module
+	url = https://github.com/TretinV3/LuaFortsAPI.git
+	branch = addon

--- a/addons/forts/info.json
+++ b/addons/forts/info.json
@@ -2,6 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "Forts API",
   "description": "Annotations for modding Forts (EarthWork Games)",
-  "size": 325226,
+  "size": 324874,
   "hasPlugin": false
 }

--- a/addons/forts/info.json
+++ b/addons/forts/info.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
+  "name": "Forts API",
+  "description": "Annotations for modding Forts (EarthWork Games)"
+}

--- a/addons/forts/info.json
+++ b/addons/forts/info.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_info.schema.json",
   "name": "Forts API",
-  "description": "Annotations for modding Forts (EarthWork Games)"
+  "description": "Annotations for modding Forts (EarthWork Games)",
+  "size": 325226,
+  "hasPlugin": false
 }


### PR DESCRIPTION
Hello,
This PR add annotations for the [Forts game](https://www.earthworkgames.com/) modding scene. Its only declarations for now. I should have followed the guide correctly, don't hesitate report any mistakes. It was previously a [editor extension](https://open-vsx.org/extension/TretinV3/forts-api-extention) but it will be way simpler as a addon and autocomplete snippets should be made into a plugin in a next update.